### PR TITLE
feat: 画像リサイズユーティリティを実装

### DIFF
--- a/app/utils/image-resize.ts
+++ b/app/utils/image-resize.ts
@@ -1,0 +1,92 @@
+const MAX_LONG_SIDE = 500;
+const JPEG_QUALITY = 0.85;
+const OUTPUT_MIME_TYPE = "image/jpeg";
+const ALLOWED_INPUT_MIME_TYPES = ["image/jpeg", "image/png"] as const;
+
+export class ImageResizeError extends Error {
+  constructor(message: string, cause?: unknown) {
+    super(message, cause !== undefined ? { cause } : undefined);
+    this.name = "ImageResizeError";
+  }
+}
+
+const calculateResizedDimensions = (
+  width: number,
+  height: number,
+): { width: number; height: number } => {
+  if (Math.max(width, height) <= MAX_LONG_SIDE) {
+    return { width, height };
+  }
+  if (width >= height) {
+    return {
+      width: MAX_LONG_SIDE,
+      height: Math.round((height * MAX_LONG_SIDE) / width),
+    };
+  }
+  return {
+    width: Math.round((width * MAX_LONG_SIDE) / height),
+    height: MAX_LONG_SIDE,
+  };
+};
+
+const readFileAsDataUrl = async (file: File): Promise<string> =>
+  new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      if (typeof reader.result !== "string") {
+        reject(new ImageResizeError("ファイルの読み込み結果が不正です"));
+        return;
+      }
+      resolve(reader.result);
+    };
+    reader.onerror = () =>
+      reject(
+        new ImageResizeError("ファイルの読み込みに失敗しました", reader.error),
+      );
+    reader.readAsDataURL(file);
+  });
+
+const loadImage = async (dataUrl: string): Promise<HTMLImageElement> =>
+  new Promise((resolve, reject) => {
+    const img = new Image();
+    img.onload = () => resolve(img);
+    img.onerror = (event) =>
+      reject(new ImageResizeError("画像の読み込みに失敗しました", event));
+    img.src = dataUrl;
+  });
+
+const drawToJpegDataUrl = (
+  img: HTMLImageElement,
+  width: number,
+  height: number,
+): string => {
+  const canvas = document.createElement("canvas");
+  canvas.width = width;
+  canvas.height = height;
+
+  const ctx = canvas.getContext("2d");
+  if (ctx === null) {
+    throw new ImageResizeError("Canvas コンテキストを取得できませんでした");
+  }
+
+  ctx.drawImage(img, 0, 0, width, height);
+  return canvas.toDataURL(OUTPUT_MIME_TYPE, JPEG_QUALITY);
+};
+
+export const resizeImage = async (file: File): Promise<string> => {
+  if (
+    !ALLOWED_INPUT_MIME_TYPES.includes(
+      file.type as (typeof ALLOWED_INPUT_MIME_TYPES)[number],
+    )
+  ) {
+    throw new ImageResizeError("対応していない画像形式です");
+  }
+
+  const dataUrl = await readFileAsDataUrl(file);
+  const img = await loadImage(dataUrl);
+  const { width, height } = calculateResizedDimensions(
+    img.naturalWidth,
+    img.naturalHeight,
+  );
+  return drawToJpegDataUrl(img, width, height);
+};


### PR DESCRIPTION
## 概要

絵本のカバー画像を localStorage に保存するために、Canvas API で長辺500pxにリサイズし Base64 data URL に変換するユーティリティを追加する。localStorage の容量制限に対応するため JPEG (品質0.85) 統一で出力する。

Closes #2

## 変更内容

| ファイル | 変更内容 |
|---|---|
| `app/utils/image-resize.ts` | `resizeImage(file)` と `ImageResizeError` を新規実装。MIMEタイプ検証、アスペクト比維持のリサイズ、Canvas描画→JPEG変換を行う |

## テスト計画

- [ ] 長辺500pxを超える画像（横長・縦長・正方形）を渡すとアスペクト比維持で長辺500pxに縮小される
- [ ] 長辺500px以下の画像は寸法を変えずJPEG再エンコードで返る
- [ ] JPEG/PNG以外のファイルを渡すと \`ImageResizeError(\"対応していない画像形式です\")\` で reject される
- [ ] 壊れた画像ファイルを渡すと \`ImageResizeError\` で reject される
- [ ] \`npm run lint\` と \`npm run typecheck\` がパスする