### PR TITLE
feat: useBooks / useFirstLaunch カスタムフックを実装

### DIFF
--- a/app/hooks/useBooks.test.ts
+++ b/app/hooks/useBooks.test.ts
@@ -1,0 +1,169 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { STORAGE_KEY } from "~/services/book-service";
+import type { Book } from "~/types/book";
+import { todayYmd } from "~/utils/date";
+import { useBooks } from "./useBooks";
+
+const sampleBook = (overrides: Partial<Book> = {}): Book => ({
+  id: "00000000-0000-4000-8000-000000000000",
+  title: "ぐりとぐら",
+  imageData: "data:image/png;base64,AAAA",
+  lastReadDate: null,
+  createdAt: "2026-04-01",
+  ...overrides,
+});
+
+const seed = (books: Book[]): void => {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(books));
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("useBooks", () => {
+  it("マウント時に localStorage の内容を同期的に読み込む（ちらつきなし）", () => {
+    const initial = sampleBook();
+    seed([initial]);
+
+    const { result } = renderHook(() => useBooks());
+
+    expect(result.current.books).toEqual([initial]);
+  });
+
+  it("addBook で localStorage と state が更新され、id / createdAt が付与される", () => {
+    const { result } = renderHook(() => useBooks());
+
+    act(() => {
+      result.current.addBook("てぶくろ", "data:image/png;base64,BBBB");
+    });
+
+    expect(result.current.books).toHaveLength(1);
+    const [added] = result.current.books;
+    expect(added.title).toBe("てぶくろ");
+    expect(added.imageData).toBe("data:image/png;base64,BBBB");
+    expect(added.lastReadDate).toBeNull();
+    expect(added.createdAt).toBe(todayYmd());
+    expect(added.id).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
+    );
+    expect(result.current.error).toBeNull();
+
+    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? "[]");
+    expect(stored).toHaveLength(1);
+    expect(stored[0].title).toBe("てぶくろ");
+  });
+
+  it("複数件 addBook しても追加順が保たれる", () => {
+    const { result } = renderHook(() => useBooks());
+
+    act(() => {
+      result.current.addBook("A", "data:image/png;base64,AAAA");
+    });
+    act(() => {
+      result.current.addBook("B", "data:image/png;base64,BBBB");
+    });
+    act(() => {
+      result.current.addBook("C", "data:image/png;base64,CCCC");
+    });
+
+    expect(result.current.books.map((b) => b.title)).toEqual(["A", "B", "C"]);
+  });
+
+  it("deleteBook で対象の絵本が削除される", () => {
+    const target = sampleBook({ id: "id-1", title: "A" });
+    const other = sampleBook({ id: "id-2", title: "B" });
+    seed([target, other]);
+
+    const { result } = renderHook(() => useBooks());
+
+    act(() => {
+      result.current.deleteBook("id-1");
+    });
+
+    expect(result.current.books).toEqual([other]);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("deleteBook で存在しない id を渡すと error state が設定される", () => {
+    seed([sampleBook()]);
+    const { result } = renderHook(() => useBooks());
+
+    act(() => {
+      result.current.deleteBook("non-existent-id");
+    });
+
+    expect(result.current.error).toBe("予期しないエラーが発生しました。");
+  });
+
+  it("recordRead で対象の lastReadDate が当日日付になる", () => {
+    const target = sampleBook({ id: "id-1" });
+    seed([target]);
+
+    const { result } = renderHook(() => useBooks());
+
+    act(() => {
+      result.current.recordRead("id-1");
+    });
+
+    expect(result.current.books[0].lastReadDate).toBe(todayYmd());
+  });
+
+  it("recordRead で存在しない id を渡すと error state が設定される", () => {
+    seed([sampleBook({ id: "id-1" })]);
+    const { result } = renderHook(() => useBooks());
+
+    act(() => {
+      result.current.recordRead("missing-id");
+    });
+
+    expect(result.current.error).toBe("予期しないエラーが発生しました。");
+  });
+
+  it("容量超過エラー時は StorageQuotaError のメッセージが error state に入り、books は変更されない", () => {
+    const initial = sampleBook();
+    seed([initial]);
+
+    const { result } = renderHook(() => useBooks());
+    expect(result.current.books).toEqual([initial]);
+
+    const setItemSpy = vi
+      .spyOn(Storage.prototype, "setItem")
+      .mockImplementation(() => {
+        throw new DOMException("quota exceeded", "QuotaExceededError");
+      });
+
+    act(() => {
+      result.current.addBook("new", "data:image/png;base64,CCCC");
+    });
+
+    expect(result.current.error).toMatch(/保存できませんでした/);
+    expect(result.current.books).toEqual([initial]);
+    expect(setItemSpy).toHaveBeenCalled();
+  });
+
+  it("成功する操作の後は error がクリアされる", () => {
+    seed([sampleBook()]);
+
+    const { result } = renderHook(() => useBooks());
+
+    const setItemSpy = vi
+      .spyOn(Storage.prototype, "setItem")
+      .mockImplementationOnce(() => {
+        throw new DOMException("quota", "QuotaExceededError");
+      });
+
+    act(() => {
+      result.current.addBook("fail", "data:image/png;base64,DDDD");
+    });
+    expect(result.current.error).not.toBeNull();
+
+    setItemSpy.mockRestore();
+
+    act(() => {
+      result.current.addBook("ok", "data:image/png;base64,EEEE");
+    });
+    expect(result.current.error).toBeNull();
+  });
+});

--- a/app/hooks/useBooks.ts
+++ b/app/hooks/useBooks.ts
@@ -1,0 +1,74 @@
+import { useCallback, useState } from "react";
+import * as bookService from "~/services/book-service";
+import { StorageQuotaError } from "~/services/book-service";
+import type { Book } from "~/types/book";
+import { todayYmd } from "~/utils/date";
+
+export type UseBooksReturn = {
+  books: Book[];
+  addBook: (title: string, imageData: string) => void;
+  deleteBook: (id: string) => void;
+  recordRead: (id: string) => void;
+  error: string | null;
+};
+
+const UNEXPECTED_ERROR_MESSAGE = "予期しないエラーが発生しました。";
+
+export const useBooks = (): UseBooksReturn => {
+  const [books, setBooks] = useState<Book[]>(() => bookService.getBooks());
+  const [error, setError] = useState<string | null>(null);
+
+  const applyBooksUpdate = useCallback((operation: () => void) => {
+    try {
+      operation();
+      setBooks(bookService.getBooks());
+      setError(null);
+    } catch (err) {
+      if (err instanceof StorageQuotaError) {
+        setError(err.message);
+        return;
+      }
+      console.error(err);
+      setError(UNEXPECTED_ERROR_MESSAGE);
+    }
+  }, []);
+
+  const addBook = useCallback(
+    (title: string, imageData: string) => {
+      applyBooksUpdate(() => {
+        bookService.addBook({
+          id: crypto.randomUUID(),
+          title,
+          imageData,
+          lastReadDate: null,
+          createdAt: todayYmd(),
+        });
+      });
+    },
+    [applyBooksUpdate],
+  );
+
+  const deleteBook = useCallback(
+    (id: string) => {
+      applyBooksUpdate(() => {
+        bookService.deleteBook(id);
+      });
+    },
+    [applyBooksUpdate],
+  );
+
+  const recordRead = useCallback(
+    (id: string) => {
+      applyBooksUpdate(() => {
+        const target = bookService.getBooks().find((b) => b.id === id);
+        if (!target) {
+          throw new Error(`Book not found: ${id}`);
+        }
+        bookService.updateBook({ ...target, lastReadDate: todayYmd() });
+      });
+    },
+    [applyBooksUpdate],
+  );
+
+  return { books, addBook, deleteBook, recordRead, error };
+};

--- a/app/hooks/useFirstLaunch.test.ts
+++ b/app/hooks/useFirstLaunch.test.ts
@@ -1,0 +1,32 @@
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { FIRST_LAUNCH_STORAGE_KEY, useFirstLaunch } from "./useFirstLaunch";
+
+describe("useFirstLaunch", () => {
+  it("フラグ未保存なら初期レンダリングから true を返す", () => {
+    const { result } = renderHook(() => useFirstLaunch());
+    expect(result.current.isFirstLaunch).toBe(true);
+  });
+
+  it("markLaunched() 後は isFirstLaunch が false になり、localStorage に記録される", () => {
+    const { result } = renderHook(() => useFirstLaunch());
+
+    act(() => {
+      result.current.markLaunched();
+    });
+
+    expect(result.current.isFirstLaunch).toBe(false);
+    expect(localStorage.getItem(FIRST_LAUNCH_STORAGE_KEY)).toBe("true");
+  });
+
+  it("markLaunched() で書き込んだフラグは再マウント後の起動でも false として読まれる", () => {
+    const first = renderHook(() => useFirstLaunch());
+    act(() => {
+      first.result.current.markLaunched();
+    });
+    first.unmount();
+
+    const second = renderHook(() => useFirstLaunch());
+    expect(second.result.current.isFirstLaunch).toBe(false);
+  });
+});

--- a/app/hooks/useFirstLaunch.ts
+++ b/app/hooks/useFirstLaunch.ts
@@ -1,0 +1,21 @@
+import { useCallback, useState } from "react";
+
+export const FIRST_LAUNCH_STORAGE_KEY = "ehon-gacha-first-launched";
+
+export type UseFirstLaunchReturn = {
+  isFirstLaunch: boolean;
+  markLaunched: () => void;
+};
+
+export const useFirstLaunch = (): UseFirstLaunchReturn => {
+  const [isFirstLaunch, setIsFirstLaunch] = useState(
+    () => localStorage.getItem(FIRST_LAUNCH_STORAGE_KEY) !== "true",
+  );
+
+  const markLaunched = useCallback(() => {
+    localStorage.setItem(FIRST_LAUNCH_STORAGE_KEY, "true");
+    setIsFirstLaunch(false);
+  }, []);
+
+  return { isFirstLaunch, markLaunched };
+};

--- a/app/services/book-service.ts
+++ b/app/services/book-service.ts
@@ -1,6 +1,6 @@
 import type { Book } from "~/types/book";
 
-const STORAGE_KEY = "ehon-gacha-books";
+export const STORAGE_KEY = "ehon-gacha-books";
 
 export class StorageQuotaError extends Error {
   constructor(cause: unknown) {

--- a/app/utils/date.ts
+++ b/app/utils/date.ts
@@ -1,0 +1,8 @@
+export const formatYmd = (date: Date): string => {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+};
+
+export const todayYmd = (): string => formatYmd(new Date());


### PR DESCRIPTION
## 概要

画面コンポーネントから localStorage を扱いやすくするためのカスタムフックを追加する。`useBooks` は絵本の CRUD と `StorageQuotaError` 含むエラー管理をまとめ、`useFirstLaunch` は初回起動モーダル制御の足場になる。これで S-01〜S-04（#7〜#11）の画面実装に着手できるようになる。

Closes #4

## 変更内容

| ファイル | 変更内容 |
|---|---|
| `app/hooks/useBooks.ts` | books state + addBook / deleteBook / recordRead / error を提供する新規フック。SPA モード前提で lazy initializer により初回描画からデータを返す |
| `app/hooks/useFirstLaunch.ts` | 初回起動フラグの管理。`FIRST_LAUNCH_STORAGE_KEY` を export |
| `app/hooks/useBooks.test.ts` | 9 ケースの単体テスト（マウント時読込 / 追加順序 / 削除 / 既読記録 / 容量エラー / 不存在 id 等） |
| `app/hooks/useFirstLaunch.test.ts` | 3 ケースの単体テスト（初期値 / markLaunched / 再マウント永続化） |
| `app/utils/date.ts` | ローカル日付を `YYYY-MM-DD` で返す `todayYmd` / `formatYmd` |
| `app/services/book-service.ts` | `STORAGE_KEY` をテストから参照できるよう export |

## テスト計画

- [ ] `npm run test` が 14 件パスする
- [ ] `npm run typecheck` がエラーなし
- [ ] `npm run lint` がエラーなし
- [ ] 将来 UI から呼んだ時に初回描画でちらつかないこと（lazy initializer 挙動）